### PR TITLE
Fix unneeded desktop fixing issue

### DIFF
--- a/fix.sh
+++ b/fix.sh
@@ -172,7 +172,7 @@ while read -r name launcher current new_icon; do
     elif [ "$mode" == "revert" ] || [ "$mode" == "l-revert" ]; then
         # Local revert
         if [ -f "$local_apps$launcher" ] && [ -f "$current" ]; then
-            if grep -Gq "Icon=$new_icon" "$local_apps$launcher"; then
+            if grep -Gq "Icon=$new_icon$" "$local_apps$launcher"; then
                 echo "F: Reverting $name..."
                 rm -f "$local_icon$new_icon"*
                 sed -i "s/Icon=${new_icon}.*/Icon=$old_icon/" "$local_apps$launcher"

--- a/fix.sh
+++ b/fix.sh
@@ -11,7 +11,7 @@
 # If not, see <http://www.gnu.org/licenses/>.
 
 # Version info
-date=201411230  # [year][month][date][extra]
+date=201503130  # [year][month][date][extra]
 
 # Locations
 git_locate="https://raw.githubusercontent.com/Foggalong/hardcode-fixer/master"

--- a/fix.sh
+++ b/fix.sh
@@ -141,7 +141,7 @@ while read -r name launcher current new_icon; do
             if [ "$current" != "steam" ]; then
                 # Local launchers
                 if [ -f "$current" ]; then # checks if icon exists to copy
-                    if grep -Fq "Icon=$current" "$local_apps$launcher"; then
+                    if grep -Gq "Icon=$current$" "$local_apps$launcher"; then
                         echo "L: Fixing $name..."
                         cp "$current" "$local_icon$new_icon"
                         sed -i "s/Icon=${old_icon}.*/Icon=$new_icon/" "$local_apps$launcher"
@@ -150,7 +150,7 @@ while read -r name launcher current new_icon; do
             else
                 # Steam launchers
                 if [ -f "$steam_icon" ]; then # checks if steam icon exists to copy
-                    if grep -Fq "Icon=$current" "$local_apps$launcher"; then
+                    if grep -Gq "Icon=$current$" "$local_apps$launcher"; then
                         echo "S: Fixing $name..."
                         cp "$steam_icon" "$local_icon${new_icon}.png"
                         sed -i "s/Icon=steam.*/Icon=$new_icon/" "$local_apps$launcher"
@@ -161,7 +161,7 @@ while read -r name launcher current new_icon; do
         # Global launchers
         if [ $mode != "local" ] && [ -f "$global_apps$launcher" ]; then
             if [ -f "$current" ]; then # checks if icon exists to copy
-                if grep -Fq "Icon=$current" "$global_apps$launcher"; then
+                if grep -Gq "Icon=$current$" "$global_apps$launcher"; then
                     echo "G: Fixing $name..."
                     cp "$current" "$global_icon$new_icon"
                     sed -i "s/Icon=${old_icon}.*/Icon=$new_icon/" "$global_apps$launcher"
@@ -172,7 +172,7 @@ while read -r name launcher current new_icon; do
     elif [ "$mode" == "revert" ] || [ "$mode" == "l-revert" ]; then
         # Local revert
         if [ -f "$local_apps$launcher" ] && [ -f "$current" ]; then
-            if grep -Fq "Icon=$new_icon" "$local_apps$launcher"; then
+            if grep -Gq "Icon=$new_icon" "$local_apps$launcher"; then
                 echo "F: Reverting $name..."
                 rm -f "$local_icon$new_icon"*
                 sed -i "s/Icon=${new_icon}.*/Icon=$old_icon/" "$local_apps$launcher"
@@ -180,7 +180,7 @@ while read -r name launcher current new_icon; do
         fi
         # Steam revert
         if [ -f "$local_apps$launcher" ] && [ -f "$steam_icon" ]; then
-            if grep -Fq "Icon=$new_icon" "$local_apps$launcher"; then
+            if grep -Gq "Icon=$new_icon$" "$local_apps$launcher"; then
                 echo "S: Reverting $name..."
                 rm -f "$local_icon$new_icon"*
                 sed -i "s/Icon=${new_icon}.*/Icon=$old_icon/" "$local_apps$launcher"
@@ -188,7 +188,7 @@ while read -r name launcher current new_icon; do
         fi
         # Global revert
         if [ $mode != "l-revert" ] && [ -f "$global_apps$launcher" ] && [ -f "$current" ]; then
-            if grep -Fq "Icon=$new_icon" "$global_apps$launcher"; then
+            if grep -Gq "Icon=$new_icon$" "$global_apps$launcher"; then
                 echo "G: Reverting $name..."
                 rm -f "$global_icon$new_icon"*
                 sed -i "s/Icon=${new_icon}.*/Icon=$old_icon/" "$global_apps$launcher"


### PR DESCRIPTION
After run it for the first time, this script will fix the steam desktop files, next time the script will try to "fix" it again even if it's already repaired.

It's happening because the greps inside the ifs always receive "true", in both situations will match the grep "Icon=steam".

To repair it I use the "-G" (--basic-regexp) instead of "-F" (--fixed-strings) and I added at final the end line signal "$"