### PR TITLE
Fix typo in icon paths for python*

### DIFF
--- a/tofix.csv
+++ b/tofix.csv
@@ -136,13 +136,13 @@ Pomidor,pomidor,/usr/share/pomidor/media/pomidor.svg,pomidor
 Prison Architect,Prison Architect,steam,steam_icon_233450
 Pycharm,pycharm,$HOME/Descargas/pycharm-community-3.1.1/bin/pycharm.png,pycharm
 pyRenamer,pyrenamer,/usr/share/pyrenamer/pyrenamer.png,pyrenamer
-Python (v2.6),python2.6,/usr/share/pixmaps/python2.6.xpm,python2.6.
-Python (v2.7),python2.7,/usr/share/pixmaps/python2.7.xpm,python2.7.
-Python (v3.0),python3.0,/usr/share/pixmaps/python3.0.xpm,python3.0.
-Python (v3.1),python3.1,/usr/share/pixmaps/python3.1.xpm,python3.1.
-Python (v3.2),python3.2,/usr/share/pixmaps/python3.2.xpm,python3.2.
-Python (v3.3),python3.3,/usr/share/pixmaps/python3.3.xpm,python3.3.
-Python (v3.4),python3.4,/usr/share/pixmaps/python3.4.xpm,python3.4.
+Python (v2.6),python2.6,/usr/share/pixmaps/python2.6.xpm,python2.6
+Python (v2.7),python2.7,/usr/share/pixmaps/python2.7.xpm,python2.7
+Python (v3.0),python3.0,/usr/share/pixmaps/python3.0.xpm,python3.0
+Python (v3.1),python3.1,/usr/share/pixmaps/python3.1.xpm,python3.1
+Python (v3.2),python3.2,/usr/share/pixmaps/python3.2.xpm,python3.2
+Python (v3.3),python3.3,/usr/share/pixmaps/python3.3.xpm,python3.3
+Python (v3.4),python3.4,/usr/share/pixmaps/python3.4.xpm,python3.4
 QGifer,qgifer,/usr/share//icons/qgifer.xpm,qgifer
 QLE,extras-qlequicklisteditor,/usr/share/pixmaps/qle_pix/logoqle2.svg,logoqle2
 qPDFview,qpdfview,/usr/share/qpdfview/qpdfview.svg,qpdfview


### PR DESCRIPTION
The extra `.` at the end of the icon name made them not show; removing it fixed the problem (using Numix-Circle theme).