### PR TITLE
Updating FreeCAD icon path

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,3 +9,15 @@ If you're an Arch user it's also available in the [AUR](https://aur.archlinux.or
 + [Use instructions](https://github.com/Foggalong/hardcode-fixer/wiki/Instructions)
 + Supported [application list](https://github.com/Foggalong/hardcode-fixer/wiki/App-Support)
 + Information on [theme support](https://github.com/Foggalong/hardcode-fixer/wiki/Theme-Support)
+
+### TOFIX Syntax
+
+```
+Application Name, Application Launcher (.desktop file), Hardcoded icon path, New icon 
+```
+
+Example:
+
+```
+Gostscript , gv , /usr/share/pixmaps/gv_icon.xpm , gv
+```

--- a/tofix.csv
+++ b/tofix.csv
@@ -1,287 +1,316 @@
-Application,Launcher,Path,Icon Name
-2048,2048,/usr/share/2048/meta/apple-touch-icon.png,2048
-2048-Qt,2048-qt,/usr/share/pixmaps/2048-qt.xpm,2048-qt
-8BitMMO,8BitMMO,steam,steam_icon_250420
-Aard Dictionary,aarddict,aarddict.png,aarddict
-Android Studio,android-studio,/usr/share/icons/androidstudio.svg,android-studio
-Anna - Extended Edition,Anna - Extended Edition,steam,steam_icon_217690
-Aptik,aptik,/usr/share/pixmaps/aptik.png,aptik
-APX,apx,/usr/share/apx/icons/apx.svg,apx
-Ardour 2,ardour2,/usr/share/ardour2/icons/ardour_icon_22px.png,ardour
-Ardour 3,ardour,/usr/share/ardour3/icons/ardour_icon_48px.png,ardour
-Ardour 3,ardour,/opt/ardour3/share/icons/ardour_icon_48px.png,ardour
-Ardour 3,ardour3,/usr/share/ardour3/icons/ardour_icon_48px.png,ardour
-Ardour 3,ardour3,/opt/ardour3/share/icons/ardour_icon_48px.png,ardour
-Ardour 4,ardour,/usr/share/ardour4/icons/ardour_icon_256px.png,ardour
-Arista,arista,/usr/share/arista/ui/icon.svg,arista
-Armagetron Advanced,armagetronad,/usr/share/pixmaps/armagetronad/icons/large/armagetronad.png,armagetronad
-Arronax,arronax,/usr/share/arronax/icons/arronax.png,arronax
-Ascii Design,ascii-design,ascii-design.png,ascii-design
-AstroMenace,astromenace,/usr/share/pixmaps/astromenace.png,astromenace
-Bastion,Bastion,steam,steam_icon_107100
-Beat Hazard,Beat Hazard,steam,steam_icon_49600
-Beat Hazard 2,Beat Hazard 2,steam,steam_icon_49610
-Bibfilex,bibfilex-qt,/opt/bibfilex/icon.png,bibfilex
-Bibfilex,bibfilex-gtk,/opt/bibfilex/icon.png,bibfilex
-BitDefender,bitdefender,/opt/BitDefender-scanner/share/doc/examples/icons/hicolor/128x128/apps/bitdefender.png,bitdefender
-Blam,blam,blam.png,blam
-BlueJ,bluej,/usr/share/java/bluej/images/bluej-icon-48.png,bluej
-Bygfoot Football Manager,bygfoot,bygfoot.xpm,bygfoot
-Calendar Indicator,calendar-indicator,/opt/extras.ubuntu.com/calendar-indicator/share/pixmaps/calendar-indicator.svg,office-calendar
-Cities in Motion 2,Cities in Motion 2,steam,steam_icon_225420
-ClipGrab,clipgrab,/usr/share/pixmaps/clipgrab.png,clipgrab
-Codelite,codelite,/usr/share/codelite/images/cubes.png,codelite
-Conky Manager,conky-manager,/usr/share/pixmaps/conky-manager.png,conky-manager
-Copy,CopyAgent,/usr/share/icons/hicolor/scalable/apps/copyagent.svg,copyagent
-Crashplan,crashplan,/usr/local/crashplan/skin/icon_app_128x128.png,crashplan
-Crashplan,crashplan,/opt/crashplan/skin/icon_app_64x64.png,crashplan
-Cura,cura,/usr/share/cura/resources/images/c.png,cura
-Cyclograph,cyclograph-gtk3,cyclograph.png,cyclograph
-Cyclograph,cyclograph-qt,cyclograph.png,cyclograph
-Desura,desura,n/a,desura
-diffpdf,diffpdf,/usr/share/pixmaps/diffpdf.png,diffpdf
-Docear,docear,/usr/share/docear/docear.png,docear
-Dogecoin QT,dogecoin,/usr/share/pixmaps/dogecoin.png,dogecoin
-DOS Box,dosbox,/usr/share/pixmaps/dosbox.png,dosbox
-Dota 2,Dota 2,steam,steam_icon_570
-dreamchess,dreamchess,/usr/share/dreamchess/icon.png,dreamchess
-Dr. Geo,drgeo2,drgeo2.png,drgeo
-Driver Manager,driver-manager,/usr/share/icons/hicolor/scalable/apps/driver-manager.svg,driver-manager
-Dwarfs!?,Dwarfs!,steam,steam_icon_35480
-Dwarfs?! - F2P,Dwarfs! - F2P,steam,steam_icon_213650
-easyLife,easylife,/usr/share/pixmaps/easylife.png,easylife
-eFax,efax-gtk,/usr/share/pixmaps/efax-gtk,efax-gtk
-Electrum,electrum,/usr/share/app-install/icons/electrum.png,electrum
-Emacs 23,emacs23,/usr/share/icons/hicolor/scalable/apps/emacs23.svg,emacs
-Emacs 24,emacs24,/usr/share/icons/hicolor/scalable/apps/emacs24.svg,emacs
-FadeIn,fadein,/usr/share/fadein/icon_app/fadein_icon_128x128.png,fadein
-FCEUX,fceux,/usr/share/pixmaps/fceux.png,fceux
-Fistful of Frags,Fistful of Frags,steam,steam_icon_265630
-FileBot,FileBot,/usr/share/filebot/icon.svg,filebot
-FlightGear Launcher,fgrun,/usr/share/pixmaps/flightgear.ico,flightgear
-FMIT,fmit,/usr/share/icons/hicolor/scalable/apps/fmit.svg,fmit
-Format Junkie,formatjunkie,/opt/extras.ubuntu.com/formatjunkie/pixmap/fjt.png,fjt
-Fotoxx,fotoxx,/usr/share/fotoxx/icons/fotoxx.png,fotoxx
-FreeCAD,freecad,/opt/freecad/data/freecad.xpm,freecad
-FreeCAD,freecad,/usr/share/freecad/freecad.xpm,freecad
-Free Chart Geany,freechartgeany,/usr/share/pixmaps/freechartgeany.png,freechartgeany
-FreeCol,freecol,/usr/share/pixmaps/freecol.xpm,freecol
-Freedroid RPG,freedroidrpg,/usr/share/icons/freedroidrpg.jpg,freedroid
-Fritzing,fritzing,/usr/share/pixmaps/fritzing_icon.png,fritzing_icon
-Gambit Chess,gambitchess,/usr/share/pixmaps/gambitchess.svg,gambitchess
-GanttProject,ganttproject,/opt/ganttproject/plugins/net.sourceforge.ganttproject/data/resources/logos/icon64.png,ganttproject
-Garry's Mod,Garry's Mod,steam,steam_icon_4000
-Gcolor2,gcolor2,/usr/share/pixmaps/gcolor2/gcolor2.xpm,gcolor2
-Gcolor2,gcolor2,/usr/share/pixmaps/gcolor2/icon.png,gcolor2
-GDebi,gdebi,gnome-mime-application-x-deb,gdebi
-Gdiskdump,gdiskdump,/usr/share/gdiskdump/data/media/gdiskdump.svg,gdiskdump
-GdMap,gdmap,gdmap_icon.png,gdmap_icon
-Gens GS,gens,/usr/share/gens/gensgs_48x48.png,gensgs
-Gens GS,gens,/usr/share/gens/gensgs_32x32.png,gensgs
-Gens GS,gens,/usr/share/gens/gens_small.png,gensgs
-GeSpeaker,gespeaker,/usr/share/gespeaker/data/icons/gespeaker.svg,gespeaker
-gFTP,gftp,gftp.png,gftp
-git-cola,git-cola,/usr/share/git-cola/icons/git.svg,git-cola
-Gmsh,gmsh,/usr/share/pixmaps/gmsh_32x32.xpm,gmsh
-GNOME Schedule,gnome-schedule,/usr/share/pixmaps/gnome-schedule/gnome-schedule.svg,gnome-schedule
-GNOME Split,gnome-split,/usr/share/pixmaps/gnome-split.png,gnome-split
-GNOME Wave Cleaner,gwc,gwc.xpm,gwc
-GNOME Weather,gnome-shell-extension-weather,org.gnome.Weather.Application,gnome-weather
-GNOME Weather (Arch),org.gnome.Weather.Application,org.gnome.Weather.Application,gnome-weather
-GNS3,gns3,/usr/share/pixmaps/gns3.xpm,gns3
-GNUbik,gnubik,gnubik.png,gnubik
-GNU Octave,www.octave.org-octave,/usr/share/octave/3.6.4/imagelib/octave-logo.svg,octave
-GNU Octave,www.octave.org-octave,/usr/share/octave/3.8.1/imagelib/octave-logo.svg,octave
-GNU Octave,www.octave.org-octave,/usr/share/octave/4.0.0/imagelib/octave-logo.svg,octave
-GoldenDict,goldendict,/usr/share/pixmaps/goldendict.png,goldendict
-Gone Home,Gone Home,steam,steam_icon_232430
-GPixPod,GPixPod,/usr/share/gpixpod/GPixPod_icon.png,GPixPod_icon
-GPRename,gprename,/usr/share/pixmaps/gprename/gprename.png,gprename
-GpsPrune,gpsprune,/usr/share/pixmaps/gpsprune.xpm,gpsprune
-Grace GTK,gracegtk,/usr/share/pixmaps/gracegtk.png,grace
-GRASS GIS,grass,/usr/share/icons/grass-64x64.png,grass
-Greenfoot,greenfoot,/usr/share/java/greenfoot/images/greenfoot-icon-48.png,greenfoot
-Grisbi,grisbi,/usr/share/pixmaps/grisbi/grisbi.svg,grisbi
-Grisbi,grisbi,/usr/share/pixmaps/grisbi/grisbi.xpm,grisbi
-Grsync,grsync,grsync.png,grsync
-Gsopcast,gsopcast,gsopcast.png,gsopcast
-GTick,gtick,/usr/share/icons/hicolor/64x64/apps/gtick.xpm,gtick
-GTimeLog,gtimelog,/usr/share/pyshared/gtimelog/gtimelog.png,gtimelog
-Guake,guake,/usr/share/pixmaps/guake/guake.png,guake
-GUVC View,guvcview,/usr/share/pixmaps/guvcview/guvcview.png,guvcview
-Hardinfo,hardinfo,/usr/share/hardinfo/pixmaps/logo.png,hardinfo
-Hipchat,atlassian-hipchat,hipchat.png,hipchat
-Hotline Miami,Hotline Miami,steam,steam_icon_219150
-HotShots,hotshots,/usr/share/pixmaps/hotshots.png,hotshots
-HP Lip,hplip,/usr/share/hplip/data/images/128x128/hp_logo.png,hp_logo
-HP Printer,hplj1020,/usr/share/pixmaps/hplj1020_icon.png,printer
-HTTraQt,httraqt,httraqt.xpm,httraqt
-I-Nex,i-nex,/usr/share/pixmaps/i-nex-128.png,i-nex-128
-IDLE,idle,/usr/share/pixmaps/idle.xpm,python-idle
-IDLE 3,idle3,/usr/share/pixmaps/idle3.xpm,python-idle
-IDLE (Python 2.7),idle-python2.7,/usr/share/pixmaps/python2.7.xpm,python-idle
-IDLE (Python 3.2),idle-python3.2,/usr/share/pixmaps/python3.2.xpm,python-idle
-IDLE (Python 3.3),idle-python3.3,/usr/share/pixmaps/python3.3.xpm,python-idle
-IDLE (Python 3.4),idle-python3.4,/usr/share/pixmaps/python3.4.xpm,python-idle
-Image Magick,display.im6,display.im6,imagemagick
-Intel Graphics Installer,intel-linux-graphics-installer,/usr/share/intel-linux-graphics-installer/images/logo.png,intel-installer
-Intellij IDE,intellij-idea,/opt/idea-IC/bin/idea.png,idea
-Jitsi,jitsi,/usr/share/pixmaps/jitsi.svg,jitsi
-Kerbal Space Program,Kerbal Space Program,steam,steam_icon_220200
-Klavaro,klavaro,/usr/share/icons/hicolor/24x24/apps/klavaro.png,klavaro
-Komodo Edit,komodo-edit,/opt/komodo-edit/share/icons/komodo48.png,komodo
-LaTeXDraw,latexdraw,/usr/share/pixmaps/latexdraw32.xpm,latexdraw
-Left 4 Dead 2,Left 4 Dead 2,steam,steam_icon_550
-Left 4 Dead 2 (beta),Left 4 Dead 2 Beta,steam,steam_icon_223530
-Lightworks,lightworks,/usr/share/lightworks/Icons/App.png,lightworks
-Lincity-NG,lincity-ng,lincity-ng.png,lincity-ng
-Lingot,lingot,/usr/share/pixmaps/lingot/lingot-icon.svg,lingot-icon
-Linphone,linphone,/usr/share/pixmaps/linphone/linphone.png,linphone
-LinSSID,linssid,/usr/share/pixmaps/linssid48.png,linssid
-Little Inferno,Little Inferno,steam,steam_icon_221260
-Ltris,ltris,/usr/share/icons/ltris48.gif,ltris
-Lucky Backup,luckybackup,/usr/share/pixmaps/luckybackup.png,luckybackup
-Lucky Backup (KDE),luckybackup-kde-su,/usr/share/pixmaps/luckybackup.png,luckybackup
-Lucky Backup (GNOME),luckybackup-gnome-su,/usr/share/pixmaps/luckybackup.png,luckybackup
-LuxRender,luxrender,/usr/share/pixmaps/luxrender.svg,luxrender
-MailNag,mailnag_config,/usr/share/mailnag/mailnag.svg,mailnag
-Mandelbulber,mandelbulber,/usr/share/mandelbulber/icons/mandelbulber.png,mandelbulber
-Master PDF Editor,MasterPdfEditor,/opt/master-pdf-editor/master-pdf-editor.png,master-pdf-editor
-MediaElch,MediaElch,/usr/share/pixmaps/MediaElch.png,mediaelch
-Mint Audio Tag,audio-tag-tool,/usr/lib/linuxmint/mintInstall/icon.svg,audio-tag-tool
-Mint Backup,mintbackup,/usr/lib/linuxmint/mintBackup/icon.png,mintbackup
-Mint Backup,mintbackup,/usr/lib/linuxmint/mintBackup/icon.svg,mintbackup
-Mint Backup,mintBackup,/usr/lib/linuxmint/mintBackup/icon.png,mintbackup
-Mint Backup,mintBackup,/usr/lib/linuxmint/mintBackup/icon.svg,mintbackup
-Mint Backup,mintBackup_mime,/usr/lib/linuxmint/mintBackup/icon.png,mintbackup 
-Mint Drivers,mintdrivers,/usr/share/icons/hicolor/scalable/apps/driver-manager.svg,driver-manager
-Mint Nanny,mintNanny,/usr/lib/linuxmint/mintNanny/icon.svg,mintNanny
-Mint Software Manager,software-manager,/usr/lib/linuxmint/mintInstall/icon.svg,software-manager
-Mint Software Manager,mintInstall,/usr/lib/linuxmint/mintInstall/icon.svg,software-manager
-Mint Software Sources,software-sources,/usr/share/icons/hicolor/scalable/apps/software-sources.svg,software-sources
-Mint Software Sources,mintsources,/usr/share/icons/hicolor/scalable/apps/software-sources.svg,software-sources
-Mint Update Manager,mintUpdate,/usr/lib/linuxmint/mintUpdate/icons/base.svg,mintUpdate
-Mint Upload Manager,mintupload,/usr/lib/linuxmint/mintUpload/icon.svg,mintUpload
-MKV Extractor GUI,mkv-extractor-gui,/usr/share/icons/hicolor/256x256/apps/mkv-extractor-gui.png,mkv-extractor-gui
-MultiBootUSB,multibootusb,/usr/share/pixmaps/multibootusb.png,multibootusb
-MultiBootUSB,multibootusb,multibootusb.png,multibootusb
-Mundus,mundus,/usr/share/pixmaps/mundus.svg,mundus
-MyTourbook,mytourbook,mytourbook.xpm,mytourbook
-My Weather Indicator,my-weather-indicator,/opt/extras.ubuntu.com/my-weather-indicator/share/pixmaps/my-weather-indicator.png,indicator-weather
-My Weather Indicator (extras),extras-my-weather-indicator,/opt/extras.ubuntu.com/my-weather-indicator/share/pixmaps/my-weather-indicator.png,indicator-weather
-Natural Selection 2,Natural Selection 2,steam,steam_icon_4920
-Netbeans IDE,netbeans,/usr/share/netbeans/7.0.1/nb/netbeans.png,netbeans
-Netbeans IDE,netbeans,/usr/share/netbeans/8.0/nb/netbeans.png,netbeans
-Netbeans IDE,netbeans-8.0.1,/usr/share/netbeans/8.0.1/nb/netbeans.png,netbeans
-Netflix,netflix,/var/lib/wine-browser-installer/NetflixIcon.png,netflix-desktop
-Ninja IDE,ninja-ide,/usr/share/ninja-ide/img/icon.png,ninja-ide
-Nitro Tasks,nitrotasks,/usr/share/nitrotasks/media/nitrotasks.png,nitrotasks
-NotifyOSD,notifyosdconf,/usr/share/notifyosdconf/not.png,notifyconf
-Nsight Eclipse Edition,nsight,/opt/cuda/libnsight/icon.xpm,nsight
-Nvidia Settings,nvidia-settings,/usr/share/pixmaps/nvidia-settings.png,nvidia-settings
-NVIDIA Visual Profiler,nvvp,/opt/cuda/libnvvp/icon.xpm,nvvp
-OCRFeeder,ocrfeeder,/usr/share/ocrfeeder/icons/ocrfeeder.svg,ocrfeeder
-openSCAD,openscad,/usr/share/pixmaps/openscad.png,openscad
-Opensong,opensong,/opt/OpenSong/opensong.xpm,opensong
-OmegaT,omegat,/usr/share/omegat/images/OmegaT.xpm,omegat
-oStorybook,oStorybook,/usr/share/oStorybook/oStorybook-icon.png,ostorybook
-PacmanXG,pacmanxg,/usr/share/pixmaps/pacmanxg.png,pacmanxg
-Pamac (Install),pamac-install,/usr/share/pamac/icons/32x32/apps/pamac.png,system-software-install
-Pamac (Update),pamac-update,/usr/share/pamac/icons/32x32/apps/pamac.png,system-software-update
-Parano,parano,parano-icon.png,parano
-Pasaffe,pasaffe,/usr/share/pasaffe/media/pasaffe.svg,pasaffe
-PDFsam,pdfsam,/usr/share/pdfsam/pdf.png,pdfsam
-Pencil,pencil,/usr/share/pencil/skin/classic/icon.svg,pencil
-Penumbra: Black Plague,Penumbra: Black Plague,steam,steam_icon_22120
-Penumbra: Overture,Penumbra: Overture,steam,steam_icon_22180
-Penumbra: Requiem,Penumbra: Requiem,steam,steam_icon_22140
-pgAdmin3,pgadmin3,/usr/share/pgadmin3/pgAdmin3.png,pgAdmin3
-pgModeler,pgmodeler,/etc/pgmodeler/pgmodeler_logo.png,pgmodeler
-PHP Storm,phpstorm,PhpStorm-133.803/bin/webide.png,phpstorm
-Pomidor,pomidor,/usr/share/pomidor/media/pomidor.svg,pomidor
-Prison Architect,Prison Architect,steam,steam_icon_233450
-ProjectLibre,projectlibre,/usr/share/pixmaps/projectlibre.png,projectlibre
-Pumpa,pumpa,/usr/share/icons/hicolor/32x32/apps/pumpa.png,pumpa
-Pycharm,pycharm,$HOME/Descargas/pycharm-community-3.1.1/bin/pycharm.png,pycharm
-Pypar 2,pypar2,pypar2.png,pypar2
-pyRenamer,pyrenamer,/usr/share/pyrenamer/pyrenamer.png,pyrenamer
-Python (v2.6),python2.6,/usr/share/pixmaps/python2.6.xpm,python
-Python (v2.7),python2.7,/usr/share/pixmaps/python2.7.xpm,python
-Python (v3.0),python3.0,/usr/share/pixmaps/python3.0.xpm,python
-Python (v3.1),python3.1,/usr/share/pixmaps/python3.1.xpm,python
-Python (v3.2),python3.2,/usr/share/pixmaps/python3.2.xpm,python
-Python (v3.3),python3.3,/usr/share/pixmaps/python3.3.xpm,python
-Python (v3.4),python3.4,/usr/share/pixmaps/python3.4.xpm,python
-QCAD,QCad,/usr/share/pixmaps/qcad_icon.png,qcad_icon
-QGifer,qgifer,/usr/share//icons/qgifer.xpm,qgifer
-QLE,extras-qlequicklisteditor,/usr/share/pixmaps/qle_pix/logoqle2.svg,logoqle2
-qPDFview,qpdfview,/usr/share/qpdfview/qpdfview.svg,qpdfview
-Qucs,qucs,/usr/share/pixmaps/big.qucs.xpm,qucs
-R,r,/usr/share/pixmaps/r.png,rlogo_icon
-Raccoon,raccoon,/usr/share/pixmaps/raccoon.svg,raccoon
-Reditr,reditr,/opt/reditr/128x128.png,reditr
-Remarkable,remarkable,/usr/share/remarkable/media/remarkable.svg,remarkable
-Robomongo,robomongo,robomongo.png,robomongo
-RubyMine,jetbrains-rubymine,/opt/RubyMine-7.0.2/bin/RMlogo.svg,rubymine
-Scid,scid,/usr/share/pixmaps/scid.xpm,scid
-Scilab,scilab,/usr/share/scilab/icons/scilab.xpm,scilab
-Scilab CLI,scilab-cli,/usr/share/scilab-cli/icons/scilab.xpm,scilab
-Scilab adv CLI,scilab-adv-cli,/usr/share/scilab-cli/icons/scilab.xpm,scilab
-ScreenRuler,gnome-screenruler,screenruler-icon-32x32.png,screenruler
-Scribus,scribus,/usr/share/scribus/icons/scribus.png,scribus
-SelekTOR,selekTOR,/usr/share/icons/selektoricon.png,selektoricon
-Shank,Shank,steam,steam_icon_6120
-Shank 2,Shank 2,steam,steam_icon_6130
-Sid Meier's Civilization V,Sid Meier's Civilization V,steam,steam_icon_8930
-Sigram,telegram,/opt/sigram/icons/icon.png,sigram
-Slingscold,slingscold,/usr/share/icons/slingscold.png,slingscold
-SmartHitHG,syntevo-smartgithg-5,/usr/share/smartgithg-5/bin/smartgithg-128.png,smartgithg
-SmartGitHG,smartgithg,/opt/smartgithg/bin/smartgithg-256.png,smartgithg
-Snapshot,Snapshot,steam,steam_icon_204220
-Soap UI 5.1.3,SoapUI-5.1.3,/opt/SmartBear/SoapUI-5.1.3/.install4j/SoapUI-5.1.3.png,soapui
-SportsTracker,SportsTracker,/opt/SportsTracker/SportsTracker.png,sportstracker
-Springseed,springseed,/usr/share/pixmaps/springseed/springseed.svg,springseed
-SQLiteBrowser,sqlitebrowser,/usr/share/pixmaps/sqlitebrowser.svg,sqlitebrowser
-Starbound,Starbound,steam,steam_icon_211820
-Steam Skin Manager,???,/usr/share/pixmaps/steamskinmanager.svg,steamskinmanager
-Streamtuner2,streamtuner2,streamtuner2.png,streamtuner2
-SuperTuxKart,supertuxkart,/usr/share/pixmaps/supertuxkart_128.png,supertuxkart
-SVG Cleaner,svgcleaner,/usr/share/icons/hicolor/scalable/apps/svgcleaner.svg,svgcleaner
-Syncthing-GTK,syncthing-gtk,/usr/share/syncthing-gtk/icons/st-logo-128.png,syncthing-gtk
-Synergy,synergy,/usr/share/icons/synergy.ico,synergy
-Team Viewer,Teamviewer-teamviewer9,/opt/teamviewer9/tv_bin/desktop/teamviewer.png,teamviewer
-Team Viewer,teamviewer-teamviewer9,/opt/teamviewer9/tv_bin/desktop/teamviewer.png,teamviewer
-Team Viewer,teamviewer-teamviewer10,/opt/teamviewer/tv_bin/desktop/teamviewer.png,teamviewer
-Team Viewer,teamviewer-teamviewer10,/opt/teamviewer10/tv_bin/desktop/teamviewer.png,teamviewer
-Telegram,telegram,/usr/share/pixmaps/telegram.png,telegram
-Terra Terminal Emulator,terra,/usr/share/terra/image/terra.svg,terra
-TimeShift,TimeShift,/usr/share/pixmaps/timeshift.png,timeshift
-Tomate,tomate,/usr/share/tomate/media/tomate.png,tomate
-Tor Browser,???,/usr/share/pixmaps/tor-browser-en.png,tor-browser-en
-Touchpad Indicator,touchpad-indicator,/usr/share/pixmaps/touchpad-indicator,touchpad-indicator
-Trelby,trelby,/opt/trelby/resources/icon256.png,trelby
-TV-MAXE,tvmaxe,/usr/share/tv-maxe/tvmaxe.png,tvmaxe
-UberWriter,uberwriter,/usr/share/uberwriter/media/uberwriter.svg,uberwriter
-UberWriter,uberwriter,/opt/extras.ubuntu.com/uberwriter/share/uberwriter/media/uberwriter.svg,uberwriter
-Ubuntu Web Browser,webbrowser-app,/usr/share/webbrowser-app/webbrowser-app.png,webbrowser-app
-Unison,unison,unison.png,unison
-Unison-GTK,unison-gtk,/usr/share/pixmaps/unison-gtk.svg,unison-gtk
-Valentina Studio,VStudio,/opt/VStudio/Resources/vstudio.png,vstudio
-Variety,variety,/usr/share/variety/media/variety.svg,variety
-Variety,variety,/opt/extras.ubuntu.com/variety/share/variety/media/variety.svg,variety
-Variety,extras-variety,/opt/extras.ubuntu.com/variety/share/variety/media/variety.svg,variety
-Viber,viber,/usr/share/pixmaps/viber.png,viber
-Warmux,warmux,warmux_128x128.png,warmux
-Widelands,widelands,/usr/share/games/widelands/pics/wl-ico-64.png,widelands
-Wireframe Sketcher,wireframesketcherstudio,/usr/share/icons/hicolor/128x128/apps/WireframeSketcher.png,wireframe-sketcher
-wxFormBuilder,wxformbuilder,wxformbuilder.png,wxformbuilder
-wxMaxima,wxmaxima,/usr/share/wxMaxima/wxmaxima.png,wxmaxima
-X-Diagnose,xdiagnose,/usr/share/xdiagnose/icons/microscope.svg,xdiagnose
-Xjump,xjump,xjump-icon.xpm,xjump-icon
-Xmind,xmind,/usr/local/xmind/xmind-logo-36.png,xmind
-Xonotic,xonotic,/usr/share/pixmaps/xonotic.png,xonotic
-YATE,yate-qt4,/usr/share/pixmaps/null_team-48.png,yate
-YATE,yate-qt4,null_team-48.png,yate
-YouTubeDL GUI,youtube-dlg,/usr/share/pixmaps/youtube-dlg.png,youtube-dlg
-Zenmap,zenmap,/usr/share/zenmap/pixmaps/zenmap.png,zenmap
-Zenmap (root),zenmap-root,/usr/share/zenmap/pixmaps/zenmap.png,zenmap
+APPLICATION                   , LAUNCHER (.dekstop)                             , PATH                                                                                                  , ICON NAME
+2048                          , 2048                                            , /usr/share/2048/meta/apple-touch-icon.png                                                             , 2048
+2048-Qt                       , 2048-qt                                         , /usr/share/pixmaps/2048-qt.xpm                                                                        , 2048-qt
+8BitMMO                       , 8BitMMO                                         , steam                                                                                                 , steam_icon_250420
+Aard Dictionary               , aarddict                                        , aarddict.png                                                                                          , aarddict
+Android Studio                , android-studio                                  , /usr/share/icons/androidstudio.svg                                                                    , android-studio
+Anna - Extended Edition       , Anna - Extended Edition                         , steam                                                                                                 , steam_icon_217690
+Aptik                         , aptik                                           , /usr/share/pixmaps/aptik.png                                                                          , aptik
+APX                           , apx                                             , /usr/share/apx/icons/apx.svg                                                                          , apx
+Ardour 2                      , ardour2                                         , /usr/share/ardour2/icons/ardour_icon_22px.png                                                         , ardour
+Ardour 3                      , ardour                                          , /opt/ardour3/share/icons/ardour_icon_48px.png                                                         , ardour
+Ardour 3                      , ardour                                          , /usr/share/ardour3/icons/ardour_icon_48px.png                                                         , ardour
+Ardour 3                      , ardour3                                         , /opt/ardour3/share/icons/ardour_icon_48px.png                                                         , ardour
+Ardour 3                      , ardour3                                         , /usr/share/ardour3/icons/ardour_icon_48px.png                                                         , ardour
+Ardour 4                      , ardour                                          , /usr/share/ardour4/icons/ardour_icon_256px.png                                                        , ardour
+Arista                        , arista                                          , /usr/share/arista/ui/icon.svg                                                                         , arista
+Armagetron Advanced           , armagetronad                                    , /usr/share/pixmaps/armagetronad/icons/large/armagetronad.png                                          , armagetronad
+Arronax                       , arronax                                         , /usr/share/arronax/icons/arronax.png                                                                  , arronax
+Ascii Design                  , ascii-design                                    , ascii-design.png                                                                                      , ascii-design
+AstroMenace                   , astromenace                                     , /usr/share/pixmaps/astromenace.png                                                                    , astromenace
+Bastion                       , Bastion                                         , steam                                                                                                 , steam_icon_107100
+Beat Hazard                   , Beat Hazard                                     , steam                                                                                                 , steam_icon_49600
+Beat Hazard 2                 , Beat Hazard 2                                   , steam                                                                                                 , steam_icon_49610
+Bibfilex                      , bibfilex-gtk                                    , /opt/bibfilex/icon.png                                                                                , bibfilex
+Bibfilex                      , bibfilex-qt                                     , /opt/bibfilex/icon.png                                                                                , bibfilex
+BitDefender                   , bitdefender                                     , /opt/BitDefender-scanner/share/doc/examples/icons/hicolor/128x128/apps/bitdefender.png                , bitdefender
+Blam                          , blam                                            , blam.png                                                                                              , blam
+BlueJ                         , bluej                                           , /usr/share/java/bluej/images/bluej-icon-48.png                                                        , bluej
+Bygfoot Football Manager      , bygfoot                                         , bygfoot.xpm                                                                                           , bygfoot
+Calendar Indicator            , calendar-indicator                              , /opt/extras.ubuntu.com/calendar-indicator/share/pixmaps/calendar-indicator.svg                        , office-calendar
+Cities in Motion 2            , Cities in Motion 2                              , steam                                                                                                 , steam_icon_225420
+ClipGrab                      , clipgrab                                        , /usr/share/pixmaps/clipgrab.png                                                                       , clipgrab
+Codelite                      , codelite                                        , /usr/share/codelite/images/cubes.png                                                                  , codelite
+Conky Manager                 , conky-manager                                   , /usr/share/pixmaps/conky-manager.png                                                                  , conky-manager
+Copy                          , copy                                            , /usr/share/icons/hicolor/scalable/apps/copyagent.svg                                                  , copy
+Copy                          , CopyAgent                                       , /usr/share/icons/hicolor/scalable/apps/copyagent.svg                                                  , copyagent
+Crashplan                     , crashplan                                       , /opt/crashplan/skin/icon_app_64x64.png                                                                , crashplan
+Crashplan                     , crashplan                                       , /usr/local/crashplan/skin/icon_app_128x128.png                                                        , crashplan
+Cura                          , cura                                            , /usr/share/cura/resources/images/c.png                                                                , cura
+Cyclograph                    , cyclograph-gtk3                                 , cyclograph.png                                                                                        , cyclograph
+Cyclograph                    , cyclograph-qt                                   , cyclograph.png                                                                                        , cyclograph
+Desura                        , desura                                          , n/a                                                                                                   , desura
+diffpdf                       , diffpdf                                         , /usr/share/pixmaps/diffpdf.png                                                                        , diffpdf
+Docear                        , docear                                          , /usr/share/docear/docear.png                                                                          , docear
+Dogecoin QT                   , dogecoin                                        , /usr/share/pixmaps/dogecoin.png                                                                       , dogecoin
+DOS Box                       , dosbox                                          , /usr/share/pixmaps/dosbox.png                                                                         , dosbox
+Dota 2                        , Dota 2                                          , steam                                                                                                 , steam_icon_570
+Dr. Geo                       , drgeo2                                          , drgeo2.png                                                                                            , drgeo
+dreamchess                    , dreamchess                                      , /usr/share/dreamchess/icon.png                                                                        , dreamchess
+Driver Manager                , driver-manager                                  , /usr/share/icons/hicolor/scalable/apps/driver-manager.svg                                             , driver-manager
+Dwarfs!?                      , Dwarfs!                                         , steam                                                                                                 , steam_icon_35480
+Dwarfs?! - F2P                , Dwarfs! - F2P                                   , steam                                                                                                 , steam_icon_213650
+easyLife                      , easylife                                        , /usr/share/pixmaps/easylife.png                                                                       , easylife
+eFax                          , efax-gtk                                        , /usr/share/pixmaps/efax-gtk                                                                           , efax-gtk
+Electrum                      , electrum                                        , /usr/share/app-install/icons/electrum.png                                                             , electrum
+Emacs 23                      , emacs23                                         , /usr/share/icons/hicolor/scalable/apps/emacs23.svg                                                    , emacs
+Emacs 24                      , emacs24                                         , /usr/share/icons/hicolor/scalable/apps/emacs24.svg                                                    , emacs
+extras-pushbullet-indicator   , extras-pushbullet-indicator                     , /opt/extras.ubuntu.com/pushbullet-indicator/share/pushbullet-indicator/icons/pushbullet-indicator.svg , pushbullet-indicator
+FadeIn                        , fadein                                          , /usr/share/fadein/icon_app/fadein_icon_128x128.png                                                    , fadein
+FCEUX                         , fceux                                           , /usr/share/pixmaps/fceux.png                                                                          , fceux
+FileBot                       , FileBot                                         , /usr/share/filebot/icon.svg                                                                           , filebot
+Fistful of Frags              , Fistful of Frags                                , steam                                                                                                 , steam_icon_265630
+FlightGear Launcher           , fgrun                                           , /usr/share/pixmaps/flightgear.ico                                                                     , flightgear
+FMIT                          , fmit                                            , /usr/share/icons/hicolor/scalable/apps/fmit.svg                                                       , fmit
+Format Junkie                 , formatjunkie                                    , /opt/extras.ubuntu.com/formatjunkie/pixmap/fjt.png                                                    , fjt
+Fotoxx                        , fotoxx                                          , /usr/share/fotoxx/icons/fotoxx.png                                                                    , fotoxx
+Free Chart Geany              , freechartgeany                                  , /usr/share/pixmaps/freechartgeany.png                                                                 , freechartgeany
+FreeCAD                       , freecad                                         , /opt/freecad/data/freecad.xpm                                                                         , freecad
+FreeCAD                       , freecad                                         , /usr/share/freecad/freecad.xpm                                                                        , freecad
+FreeCol                       , freecol                                         , /usr/share/pixmaps/freecol.xpm                                                                        , freecol
+Freedroid RPG                 , freedroidrpg                                    , /usr/share/icons/freedroidrpg.jpg                                                                     , freedroid
+Fritzing                      , fritzing                                        , /usr/share/pixmaps/fritzing_icon.png                                                                  , fritzing_icon
+Gambit Chess                  , gambitchess                                     , /usr/share/pixmaps/gambitchess.svg                                                                    , gambitchess
+GanttProject                  , ganttproject                                    , /opt/ganttproject/plugins/net.sourceforge.ganttproject/data/resources/logos/icon64.png                , ganttproject
+Garry's Mod                   , Garry's Mod                                     , steam                                                                                                 , steam_icon_4000
+Gcolor2                       , gcolor2                                         , /usr/share/pixmaps/gcolor2/gcolor2.xpm                                                                , gcolor2
+Gcolor2                       , gcolor2                                         , /usr/share/pixmaps/gcolor2/icon.png                                                                   , gcolor2
+GDebi                         , gdebi                                           , gnome-mime-application-x-deb                                                                          , gdebi
+Gdiskdump                     , gdiskdump                                       , /usr/share/gdiskdump/data/media/gdiskdump.svg                                                         , gdiskdump
+GdMap                         , gdmap                                           , gdmap_icon.png                                                                                        , gdmap_icon
+Gens GS                       , gens                                            , /usr/share/gens/gens_small.png                                                                        , gensgs
+Gens GS                       , gens                                            , /usr/share/gens/gensgs_32x32.png                                                                      , gensgs
+Gens GS                       , gens                                            , /usr/share/gens/gensgs_48x48.png                                                                      , gensgs
+GeSpeaker                     , gespeaker                                       , /usr/share/gespeaker/data/icons/gespeaker.svg                                                         , gespeaker
+gFTP                          , gftp                                            , gftp.png                                                                                              , gftp
+git-cola                      , git-cola                                        , /usr/share/git-cola/icons/git.svg                                                                     , git-cola
+Gmsh                          , gmsh                                            , /usr/share/pixmaps/gmsh_32x32.xpm                                                                     , gmsh
+GNOME Schedule                , gnome-schedule                                  , /usr/share/pixmaps/gnome-schedule/gnome-schedule.svg                                                  , gnome-schedule
+GNOME Split                   , gnome-split                                     , /usr/share/pixmaps/gnome-split.png                                                                    , gnome-split
+GNOME Wave Cleaner            , gwc                                             , gwc.xpm                                                                                               , gwc
+GNOME Weather                 , gnome-shell-extension-weather                   , org.gnome.Weather.Application                                                                         , gnome-weather
+GNOME Weather (Arch)          , org.gnome.Weather.Application                   , org.gnome.Weather.Application                                                                         , gnome-weather
+GNS3                          , gns3                                            , /usr/share/pixmaps/gns3.xpm                                                                           , gns3
+GNU Octave                    , www.octave.org-octave                           , /usr/share/octave/3.6.4/imagelib/octave-logo.svg                                                      , octave
+GNU Octave                    , www.octave.org-octave                           , /usr/share/octave/3.8.1/imagelib/octave-logo.svg                                                      , octave
+GNU Octave                    , www.octave.org-octave                           , /usr/share/octave/4.0.0/imagelib/octave-logo.svg                                                      , octave
+GNUbik                        , gnubik                                          , gnubik.png                                                                                            , gnubik
+GoldenDict                    , goldendict                                      , /usr/share/pixmaps/goldendict.png                                                                     , goldendict
+Gone Home                     , Gone Home                                       , steam                                                                                                 , steam_icon_232430
+Google2Ubuntu                 , google2ubuntu                                   , /usr/share/google2ubuntu/resources/icons.png                                                          , google2ubuntu
+Google2Ubuntu                 , google2ubuntu-gui                               , /usr/share/google2ubuntu/resources/icons.png                                                          , google2ubuntu
+Gostscript                    , gv                                              , /usr/share/pixmaps/gv_icon.xpm                                                                        , gv
+GPixPod                       , GPixPod                                         , /usr/share/gpixpod/GPixPod_icon.png                                                                   , GPixPod_icon
+GPRename                      , gprename                                        , /usr/share/pixmaps/gprename/gprename.png                                                              , gprename
+GpsPrune                      , gpsprune                                        , /usr/share/pixmaps/gpsprune.xpm                                                                       , gpsprune
+Grace GTK                     , gracegtk                                        , /usr/share/pixmaps/gracegtk.png                                                                       , grace
+GRASS GIS                     , grass                                           , /usr/share/icons/grass-64x64.png                                                                      , grass
+Greenfoot                     , greenfoot                                       , /usr/share/java/greenfoot/images/greenfoot-icon-48.png                                                , greenfoot
+Grisbi                        , grisbi                                          , /usr/share/pixmaps/grisbi/grisbi.svg                                                                  , grisbi
+Grisbi                        , grisbi                                          , /usr/share/pixmaps/grisbi/grisbi.xpm                                                                  , grisbi
+Grsync                        , grsync                                          , grsync.png                                                                                            , grsync
+Gsopcast                      , gsopcast                                        , gsopcast.png                                                                                          , gsopcast
+GTick                         , gtick                                           , /usr/share/icons/hicolor/64x64/apps/gtick.xpm                                                         , gtick
+GTimeLog                      , gtimelog                                        , /usr/share/pyshared/gtimelog/gtimelog.png                                                             , gtimelog
+GTK Term                      , gtkterm                                         , gtkterm                                                                                               , gtkterm
+Guake                         , guake                                           , /usr/share/pixmaps/guake/guake.png                                                                    , guake
+GUVC View                     , guvcview                                        , /usr/share/pixmaps/guvcview/guvcview.png                                                              , guvcview
+Hardinfo                      , hardinfo                                        , /usr/share/hardinfo/pixmaps/logo.png                                                                  , hardinfo
+Hipchat                       , atlassian-hipchat                               , hipchat.png                                                                                           , hipchat
+Hotline Miami                 , Hotline Miami                                   , steam                                                                                                 , steam_icon_219150
+HotShots                      , hotshots                                        , /usr/share/pixmaps/hotshots.png                                                                       , hotshots
+HP Lip                        , hplip                                           , /usr/share/hplip/data/images/128x128/hp_logo.png                                                      , hp_logo
+HP Printer                    , hplj1020                                        , /usr/share/pixmaps/hplj1020_icon.png                                                                  , printer
+HTTraQt                       , httraqt                                         , httraqt.xpm                                                                                           , httraqt
+I-Nex                         , i-nex                                           , /usr/share/pixmaps/i-nex-128.png                                                                      , i-nex-128
+I-Nex Library                 , i-nex-library                                   , /usr/share/pixmaps/i-nex-128.png                                                                      , i-nex-128
+ibus-setup-bopomofo           , ibus-setup-bopomofo                             , /usr/share/ibus-pinyin/icons/ibus-bopomofo.svg                                                        , ibus-bopomofo
+ibus-setup-pinyin             , ibus-setup-pinyin                               , /usr/share/ibus-pinyin/icons/ibus-pinyin.svg                                                          , ibus-pinyin
+IDLE                          , idle                                            , /usr/share/pixmaps/idle.xpm                                                                           , python-idle
+IDLE (Python 2.7)             , idle-python2.7                                  , /usr/share/pixmaps/python2.7.xpm                                                                      , python-idle
+IDLE (Python 3.2)             , idle-python3.2                                  , /usr/share/pixmaps/python3.2.xpm                                                                      , python-idle
+IDLE (Python 3.3)             , idle-python3.3                                  , /usr/share/pixmaps/python3.3.xpm                                                                      , python-idle
+IDLE (Python 3.4)             , idle-python3.4                                  , /usr/share/pixmaps/python3.4.xpm                                                                      , python-idle
+IDLE 3                        , idle3                                           , /usr/share/pixmaps/idle3.xpm                                                                          , python-idle
+Image Magick                  , display.im6                                     , display.im6                                                                                           , imagemagick
+Intel Graphics Installer      , intel-linux-graphics-installer                  , /usr/share/intel-linux-graphics-installer/images/logo.png                                             , intel-installer
+Intellij IDE                  , intellij-idea                                   , /opt/idea-IC/bin/idea.png                                                                             , idea
+Jitsi                         , jitsi                                           , /usr/share/pixmaps/jitsi.svg                                                                          , jitsi
+JSTest                        , jstest-gtk                                      , jstest-gtk.png                                                                                        , jstest-gtk
+Kerbal Space Program          , Kerbal Space Program                            , steam                                                                                                 , steam_icon_220200
+Klavaro                       , klavaro                                         , /usr/share/icons/hicolor/24x24/apps/klavaro.png                                                       , klavaro
+Komodo Edit                   , komodo-edit                                     , /opt/komodo-edit/share/icons/komodo48.png                                                             , komodo
+LaTeXDraw                     , latexdraw                                       , /usr/share/pixmaps/latexdraw32.xpm                                                                    , latexdraw
+Left 4 Dead 2                 , Left 4 Dead 2                                   , steam                                                                                                 , steam_icon_550
+Left 4 Dead 2 (beta)          , Left 4 Dead 2 Beta                              , steam                                                                                                 , steam_icon_223530
+Lightworks                    , lightworks                                      , /usr/share/lightworks/Icons/App.png                                                                   , lightworks
+Lincity-NG                    , lincity-ng                                      , lincity-ng.png                                                                                        , lincity-ng
+Lingot                        , lingot                                          , /usr/share/pixmaps/lingot/lingot-icon.svg                                                             , lingot-icon
+Linphone                      , linphone                                        , /usr/share/pixmaps/linphone/linphone.png                                                              , linphone
+LinSSID                       , linssid                                         , /usr/share/pixmaps/linssid48.png                                                                      , linssid
+Little Inferno                , Little Inferno                                  , steam                                                                                                 , steam_icon_221260
+Ltris                         , ltris                                           , /usr/share/icons/ltris48.gif                                                                          , ltris
+Lucky Backup                  , luckybackup                                     , /usr/share/pixmaps/luckybackup.png                                                                    , luckybackup
+Lucky Backup (GNOME)          , luckybackup-gnome-su                            , /usr/share/pixmaps/luckybackup.png                                                                    , luckybackup
+Lucky Backup (KDE)            , luckybackup-kde-su                              , /usr/share/pixmaps/luckybackup.png                                                                    , luckybackup
+LuxRender                     , luxrender                                       , /usr/share/pixmaps/luxrender.svg                                                                      , luxrender
+MailNag                       , mailnag_config                                  , /usr/share/mailnag/mailnag.svg                                                                        , mailnag
+Mandelbulber                  , mandelbulber                                    , /usr/share/mandelbulber/icons/mandelbulber.png                                                        , mandelbulber
+Master PDF Editor             , MasterPdfEditor                                 , /opt/master-pdf-editor/master-pdf-editor.png                                                          , master-pdf-editor
+MediaElch                     , MediaElch                                       , /usr/share/pixmaps/MediaElch.png                                                                      , mediaelch
+Mint Audio Tag                , audio-tag-tool                                  , /usr/lib/linuxmint/mintInstall/icon.svg                                                               , audio-tag-tool
+Mint Backup                   , mintbackup                                      , /usr/lib/linuxmint/mintBackup/icon.png                                                                , mintbackup
+Mint Backup                   , mintBackup                                      , /usr/lib/linuxmint/mintBackup/icon.png                                                                , mintbackup
+Mint Backup                   , mintbackup                                      , /usr/lib/linuxmint/mintBackup/icon.svg                                                                , mintbackup
+Mint Backup                   , mintBackup                                      , /usr/lib/linuxmint/mintBackup/icon.svg                                                                , mintbackup
+Mint Backup                   , mintBackup_mime                                 , /usr/lib/linuxmint/mintBackup/icon.png                                                                , mintbackup
+Mint Drivers                  , mintdrivers                                     , /usr/share/icons/hicolor/scalable/apps/driver-manager.svg                                             , driver-manager
+Mint Nanny                    , mintNanny                                       , /usr/lib/linuxmint/mintNanny/icon.svg                                                                 , mintNanny
+Mint Software Manager         , mintInstall                                     , /usr/lib/linuxmint/mintInstall/icon.svg                                                               , software-manager
+Mint Software Manager         , software-manager                                , /usr/lib/linuxmint/mintInstall/icon.svg                                                               , software-manager
+Mint Software Sources         , mintsources                                     , /usr/share/icons/hicolor/scalable/apps/software-sources.svg                                           , software-sources
+Mint Software Sources         , software-sources                                , /usr/share/icons/hicolor/scalable/apps/software-sources.svg                                           , software-sources
+Mint Update Manager           , mintUpdate                                      , /usr/lib/linuxmint/mintUpdate/icons/base.svg                                                          , mintUpdate
+Mint Upload Manager           , mintupload                                      , /usr/lib/linuxmint/mintUpload/icon.svg                                                                , mintUpload
+MKV Extractor GUI             , mkv-extractor-gui                               , /usr/share/icons/hicolor/256x256/apps/mkv-extractor-gui.png                                           , mkv-extractor-gui
+MS Calendar                   , calendar                                        , /usr/share/icons/microsoftonline/0_calendar.png                                                       , ms_calendar
+MS Excel                      , excel                                           , /usr/share/icons/microsoftonline/0_excelonline.png                                                    , ms_excel
+MS Excel                      , excel                                           , /usr/share/icons/microsoftonline/0_wordonline.png                                                     , ms_excel
+MS Onedrive                   , onedrive                                        , /usr/share/icons/microsoftonline/0_onedrive.png                                                       , ms_onedrive
+MS Onenote                    , onenote                                         , /usr/share/icons/microsoftonline/0_onenoteonline.png                                                  , ms_onenote
+MS Outlook                    , outlook                                         , /usr/share/icons/microsoftonline/0_outlook.png                                                        , ms_outlook
+MS People                     , people                                          , /usr/share/icons/microsoftonline/0_people.png                                                         , ms_people
+MS Powerpoint                 , powerpiont                                      , /usr/share/icons/microsoftonline/0_powerpointonline.png                                               , ms_powerpoint
+MS Word                       , word                                            , /usr/share/icons/microsoftonline/0_wordonline.png                                                     , ms_word
+MultiBootUSB                  , multibootusb                                    , /usr/share/pixmaps/multibootusb.png                                                                   , multibootusb
+MultiBootUSB                  , multibootusb                                    , multibootusb.png                                                                                      , multibootusb
+Mundus                        , mundus                                          , /usr/share/pixmaps/mundus.svg                                                                         , mundus
+My Weather Indicator          , my-weather-indicator                            , /opt/extras.ubuntu.com/my-weather-indicator/share/pixmaps/my-weather-indicator.png                    , indicator-weather
+My Weather Indicator (extras) , extras-my-weather-indicator                     , /opt/extras.ubuntu.com/my-weather-indicator/share/pixmaps/my-weather-indicator.png                    , indicator-weather
+MyTourbook                    , mytourbook                                      , mytourbook.xpm                                                                                        , mytourbook
+Natural Selection 2           , Natural Selection 2                             , steam                                                                                                 , steam_icon_4920
+Netbeans IDE                  , netbeans                                        , /usr/share/netbeans/7.0.1/nb/netbeans.png                                                             , netbeans
+Netbeans IDE                  , netbeans                                        , /usr/share/netbeans/8.0/nb/netbeans.png                                                               , netbeans
+Netbeans IDE                  , netbeans-8.0.1                                  , /usr/share/netbeans/8.0.1/nb/netbeans.png                                                             , netbeans
+Netflix                       , netflix                                         , /var/lib/wine-browser-installer/NetflixIcon.png                                                       , netflix-desktop
+Ninja IDE                     , ninja-ide                                       , /usr/share/ninja-ide/img/icon.png                                                                     , ninja-ide
+Nitro Tasks                   , nitrotasks                                      , /usr/share/nitrotasks/media/nitrotasks.png                                                            , nitrotasks
+NotifyOSD                     , notifyosdconf                                   , /usr/share/notifyosdconf/not.png                                                                      , notifyconf
+Nsight Eclipse Edition        , nsight                                          , /opt/cuda/libnsight/icon.xpm                                                                          , nsight
+Nvidia Settings               , nvidia-settings                                 , /usr/share/pixmaps/nvidia-settings.png                                                                , nvidia-settings
+NVIDIA Visual Profiler        , nvvp                                            , /opt/cuda/libnvvp/icon.xpm                                                                            , nvvp
+OCRFeeder                     , ocrfeeder                                       , /usr/share/ocrfeeder/icons/ocrfeeder.svg                                                              , ocrfeeder
+OmegaT                        , omegat                                          , /usr/share/omegat/images/OmegaT.xpm                                                                   , omegat
+openSCAD                      , openscad                                        , /usr/share/pixmaps/openscad.png                                                                       , openscad
+Opensong                      , opensong                                        , /opt/OpenSong/opensong.xpm                                                                            , opensong
+oStorybook                    , oStorybook                                      , /usr/share/oStorybook/oStorybook-icon.png                                                             , ostorybook
+PacmanXG                      , pacmanxg                                        , /usr/share/pixmaps/pacmanxg.png                                                                       , pacmanxg
+Pamac (Install)               , pamac-install                                   , /usr/share/pamac/icons/32x32/apps/pamac.png                                                           , system-software-install
+Pamac (Update)                , pamac-update                                    , /usr/share/pamac/icons/32x32/apps/pamac.png                                                           , system-software-update
+Parano                        , parano                                          , parano-icon.png                                                                                       , parano
+Pasaffe                       , pasaffe                                         , /usr/share/pasaffe/media/pasaffe.svg                                                                  , pasaffe
+PDFsam                        , pdfsam                                          , /usr/share/pdfsam/pdf.png                                                                             , pdfsam
+Pencil                        , pencil                                          , /usr/share/pencil/skin/classic/icon.svg                                                               , pencil
+Penumbra: Black Plague        , Penumbra: Black Plague                          , steam                                                                                                 , steam_icon_22120
+Penumbra: Overture            , Penumbra: Overture                              , steam                                                                                                 , steam_icon_22180
+Penumbra: Requiem             , Penumbra: Requiem                               , steam                                                                                                 , steam_icon_22140
+pgAdmin3                      , pgadmin3                                        , /usr/share/pgadmin3/pgAdmin3.png                                                                      , pgAdmin3
+pgModeler                     , pgmodeler                                       , /etc/pgmodeler/pgmodeler_logo.png                                                                     , pgmodeler
+PHP Storm                     , phpstorm                                        , PhpStorm-133.803/bin/webide.png                                                                       , phpstorm
+Pomidor                       , pomidor                                         , /usr/share/pomidor/media/pomidor.svg                                                                  , pomidor
+Prison Architect              , Prison Architect                                , steam                                                                                                 , steam_icon_233450
+ProjectLibre                  , projectlibre                                    , /usr/share/pixmaps/projectlibre.png                                                                   , projectlibre
+Pumpa                         , pumpa                                           , /usr/share/icons/hicolor/32x32/apps/pumpa.png                                                         , pumpa
+Pycharm                       , pycharm                                         , $HOME/Descargas/pycharm-community-3.1.1/bin/pycharm.png                                               , pycharm
+Pypar 2                       , pypar2                                          , pypar2.png                                                                                            , pypar2
+pyRenamer                     , pyrenamer                                       , /usr/share/pyrenamer/pyrenamer.png                                                                    , pyrenamer
+Python (v2.6)                 , python2.6                                       , /usr/share/pixmaps/python2.6.xpm                                                                      , python
+Python (v2.7)                 , python2.7                                       , /usr/share/pixmaps/python2.7.xpm                                                                      , python
+Python (v3.0)                 , python3.0                                       , /usr/share/pixmaps/python3.0.xpm                                                                      , python
+Python (v3.1)                 , python3.1                                       , /usr/share/pixmaps/python3.1.xpm                                                                      , python
+Python (v3.2)                 , python3.2                                       , /usr/share/pixmaps/python3.2.xpm                                                                      , python
+Python (v3.3)                 , python3.3                                       , /usr/share/pixmaps/python3.3.xpm                                                                      , python
+Python (v3.4)                 , python3.4                                       , /usr/share/pixmaps/python3.4.xpm                                                                      , python
+QCAD                          , QCad                                            , /usr/share/pixmaps/qcad_icon.png                                                                      , qcad_icon
+QGifer                        , qgifer                                          , /usr/share//icons/qgifer.xpm                                                                          , qgifer
+QLE                           , extras-qlequicklisteditor                       , /usr/share/pixmaps/qle_pix/logoqle2.svg                                                               , logoqle2
+qPDFview                      , qpdfview                                        , /usr/share/qpdfview/qpdfview.svg                                                                      , qpdfview
+Qucs                          , qucs                                            , /usr/share/pixmaps/big.qucs.xpm                                                                       , qucs
+R                             , r                                               , /usr/share/pixmaps/r.png                                                                              , rlogo_icon
+Raccoon                       , raccoon                                         , /usr/share/pixmaps/raccoon.svg                                                                        , raccoon
+Reditr                        , chrome-pmfcbbijgnhoebddbjpmlikabnbnddgb-Default , reditr                                                                                                , reditr
+Reditr                        , reditr                                          , /opt/reditr/128x128.png                                                                               , reditr
+Remarkable                    , remarkable                                      , /usr/share/remarkable/media/remarkable.svg                                                            , remarkable
+RFB Receitanet                , rfb-receitanet                                  , /opt/Programas RFB/Receitanet/imagens/Receitanet.xpm                                                  , receitanet
+RFB Receitanet Ajuda          , rfb-receitanet-ajuda                            , /opt/Programas RFB/Receitanet/imagens/Ajuda.xpm                                                       , receitanet-ajuda
+Robomongo                     , robomongo                                       , robomongo.png                                                                                         , robomongo
+RubyMine                      , jetbrains-rubymine                              , /opt/RubyMine-7.0.2/bin/RMlogo.svg                                                                    , rubymine
+Scid                          , scid                                            , /usr/share/pixmaps/scid.xpm                                                                           , scid
+Scilab                        , scilab                                          , /usr/share/scilab/icons/scilab.xpm                                                                    , scilab
+Scilab adv CLI                , scilab-adv-cli                                  , /usr/share/scilab-cli/icons/scilab.xpm                                                                , scilab
+Scilab CLI                    , scilab-cli                                      , /usr/share/scilab-cli/icons/scilab.xpm                                                                , scilab
+ScreenRuler                   , gnome-screenruler                               , screenruler-icon-32x32.png                                                                            , screenruler
+Scribus                       , scribus                                         , /usr/share/scribus/icons/scribus.png                                                                  , scribus
+SelekTOR                      , selektor                                        , /opt/selektor/resources/selektoricon.png                                                              , selektoricon
+SelekTOR                      , selektor                                        , /usr/share/icons/selektor-app.png                                                                     , selektoricon
+SelekTOR                      , selekTOR                                        , /usr/share/icons/selektoricon.png                                                                     , selektoricon
+SelekTOR Proxy Reset          , selektor-proxy-reset                            , /opt/selektor/resources/selektoricon.png                                                              , selektoricon
+SelekTOR Proxy Reset          , selektor-proxy-reset                            , /usr/share/icons/selektor-app.png                                                                     , selektoricon
+Shank                         , Shank                                           , steam                                                                                                 , steam_icon_6120
+Shank 2                       , Shank 2                                         , steam                                                                                                 , steam_icon_6130
+Sid Meier's Civilization V    , Sid Meier's Civilization V                      , steam                                                                                                 , steam_icon_8930
+Sigram                        , telegram                                        , /opt/sigram/icons/icon.png                                                                            , sigram
+Slingscold                    , slingscold                                      , /usr/share/icons/slingscold.png                                                                       , slingscold
+SmartGitHG                    , smartgithg                                      , /opt/smartgithg/bin/smartgithg-256.png                                                                , smartgithg
+SmartHitHG                    , syntevo-smartgithg-5                            , /usr/share/smartgithg-5/bin/smartgithg-128.png                                                        , smartgithg
+Snapshot                      , Snapshot                                        , steam                                                                                                 , steam_icon_204220
+Soap UI 5.1.3                 , SoapUI-5.1.3                                    , /opt/SmartBear/SoapUI-5.1.3/.install4j/SoapUI-5.1.3.png                                               , soapui
+SportsTracker                 , SportsTracker                                   , /opt/SportsTracker/SportsTracker.png                                                                  , sportstracker
+Springseed                    , springseed                                      , /usr/share/pixmaps/springseed/springseed.svg                                                          , springseed
+SQLiteBrowser                 , sqlitebrowser                                   , /usr/share/pixmaps/sqlitebrowser.svg                                                                  , sqlitebrowser
+Starbound                     , Starbound                                       , steam                                                                                                 , steam_icon_211820
+Steam Skin Manager            , ???                                             , /usr/share/pixmaps/steamskinmanager.svg                                                               , steamskinmanager
+Streamtuner2                  , streamtuner2                                    , streamtuner2.png                                                                                      , streamtuner2
+SuperTuxKart                  , supertuxkart                                    , /usr/share/pixmaps/supertuxkart_128.png                                                               , supertuxkart
+SVG Cleaner                   , svgcleaner                                      , /usr/share/icons/hicolor/scalable/apps/svgcleaner.svg                                                 , svgcleaner
+Syncthing-GTK                 , syncthing-gtk                                   , /usr/share/syncthing-gtk/icons/st-logo-128.png                                                        , syncthing-gtk
+Synergy                       , synergy                                         , /usr/share/icons/synergy.ico                                                                          , synergy
+Team Viewer                   , teamviewer-teamviewer10                         , /opt/teamviewer/tv_bin/desktop/teamviewer.png                                                         , teamviewer
+Team Viewer                   , teamviewer-teamviewer10                         , /opt/teamviewer10/tv_bin/desktop/teamviewer.png                                                       , teamviewer
+Team Viewer                   , Teamviewer-teamviewer9                          , /opt/teamviewer9/tv_bin/desktop/teamviewer.png                                                        , teamviewer
+Team Viewer                   , teamviewer-teamviewer9                          , /opt/teamviewer9/tv_bin/desktop/teamviewer.png                                                        , teamviewer
+Telegram                      , telegram                                        , /usr/share/pixmaps/telegram.png                                                                       , telegram
+Terra Terminal Emulator       , terra                                           , /usr/share/terra/image/terra.svg                                                                      , terra
+TimeShift                     , TimeShift                                       , /usr/share/pixmaps/timeshift.png                                                                      , timeshift
+Tomate                        , tomate                                          , /usr/share/tomate/media/tomate.png                                                                    , tomate
+Tor Browser                   , ???                                             , /usr/share/pixmaps/tor-browser-en.png                                                                 , tor-browser-en
+Tor Browser                   , tor-browser-en                                  , /usr/share/pixmaps/tor-browser-en.png                                                                 , tor-browser-en
+Touchpad Indicator            , touchpad-indicator                              , /usr/share/pixmaps/touchpad-indicator                                                                 , touchpad-indicator
+Trelby                        , trelby                                          , /opt/trelby/resources/icon256.png                                                                     , trelby
+TV-MAXE                       , tvmaxe                                          , /usr/share/tv-maxe/tvmaxe.png                                                                         , tvmaxe
+UberWriter                    , uberwriter                                      , /opt/extras.ubuntu.com/uberwriter/share/uberwriter/media/uberwriter.svg                               , uberwriter
+UberWriter                    , uberwriter                                      , /usr/share/uberwriter/media/uberwriter.svg                                                            , uberwriter
+Ubuntu Web Browser            , webbrowser-app                                  , /usr/share/webbrowser-app/webbrowser-app.png                                                          , webbrowser-app
+Unison                        , unison                                          , unison.png                                                                                            , unison
+Unison-GTK                    , unison-gtk                                      , /usr/share/pixmaps/unison-gtk.svg                                                                     , unison-gtk
+Valentina Studio              , VStudio                                         , /opt/VStudio/Resources/vstudio.png                                                                    , vstudio
+Variety                       , extras-variety                                  , /opt/extras.ubuntu.com/variety/share/variety/media/variety.svg                                        , variety
+Variety                       , variety                                         , /opt/extras.ubuntu.com/variety/share/variety/media/variety.svg                                        , variety
+Variety                       , variety                                         , /usr/share/variety/media/variety.svg                                                                  , variety
+Viber                         , viber                                           , /usr/share/pixmaps/viber.png                                                                          , viber
+Viva                          , viva                                            , viva.png                                                                                              , viva
+Warmux                        , warmux                                          , warmux_128x128.png                                                                                    , warmux
+Widelands                     , widelands                                       , /usr/share/games/widelands/pics/wl-ico-64.png                                                         , widelands
+WinUSB                        , winusbgui                                       , winusbgui-icon.png                                                                                    , winusb
+Wireframe Sketcher            , wireframesketcherstudio                         , /usr/share/icons/hicolor/128x128/apps/WireframeSketcher.png                                           , wireframe-sketcher
+wxFormBuilder                 , wxformbuilder                                   , wxformbuilder.png                                                                                     , wxformbuilder
+wxMaxima                      , wxmaxima                                        , /usr/share/wxMaxima/wxmaxima.png                                                                      , wxmaxima
+X-Diagnose                    , xdiagnose                                       , /usr/share/xdiagnose/icons/microscope.svg                                                             , xdiagnose
+Xjump                         , xjump                                           , xjump-icon.xpm                                                                                        , xjump-icon
+Xmind                         , xmind                                           , /usr/local/xmind/xmind-logo-36.png                                                                    , xmind
+Xonotic                       , xonotic                                         , /usr/share/pixmaps/xonotic.png                                                                        , xonotic
+YATE                          , yate-qt4                                        , /usr/share/pixmaps/null_team-48.png                                                                   , yate
+YATE                          , yate-qt4                                        , null_team-48.png                                                                                      , yate
+YouTubeDL GUI                 , youtube-dlg                                     , /usr/share/pixmaps/youtube-dlg.png                                                                    , youtube-dlg
+Zenmap                        , zenmap                                          , /usr/share/zenmap/pixmaps/zenmap.png                                                                  , zenmap
+Zenmap (root)                 , zenmap-root                                     , /usr/share/zenmap/pixmaps/zenmap.png                                                                  , zenmap

--- a/tofix.csv
+++ b/tofix.csv
@@ -62,6 +62,7 @@ FlightGear Launcher,fgrun,/usr/share/pixmaps/flightgear.ico,flightgear
 FMIT,fmit,/usr/share/icons/hicolor/scalable/apps/fmit.svg,fmit
 Format Junkie,formatjunkie,/opt/extras.ubuntu.com/formatjunkie/pixmap/fjt.png,fjt
 Fotoxx,fotoxx,/usr/share/fotoxx/icons/fotoxx.png,fotoxx
+FreeCAD,freecad,/opt/freecad/data/freecad.xpm,freecad
 FreeCAD,freecad,/usr/share/freecad/freecad.xpm,freecad
 Free Chart Geany,freechartgeany,/usr/share/pixmaps/freechartgeany.png,freechartgeany
 FreeCol,freecol,/usr/share/pixmaps/freecol.xpm,freecol

--- a/tofix.csv
+++ b/tofix.csv
@@ -61,7 +61,7 @@ FlightGear Launcher,fgrun,/usr/share/pixmaps/flightgear.ico,flightgear
 FMIT,fmit,/usr/share/icons/hicolor/scalable/apps/fmit.svg,fmit
 Format Junkie,formatjunkie,/opt/extras.ubuntu.com/formatjunkie/pixmap/fjt.png,fjt
 Fotoxx,fotoxx,/usr/share/fotoxx/icons/fotoxx.png,fotoxx
-FreeCAD,freecad,/opt/freecad/data/freecad.xpm,freecad
+FreeCAD,freecad,/usr/share/freecad/freecad.xpm,freecad
 Free Chart Geany,freechartgeany,/usr/share/pixmaps/freechartgeany.png,freechartgeany
 FreeCol,freecol,/usr/share/pixmaps/freecol.xpm,freecol
 Freedroid RPG,freedroidrpg,/usr/share/icons/freedroidrpg.jpg,freedroid

--- a/tofix.csv
+++ b/tofix.csv
@@ -32,6 +32,7 @@ Cities in Motion 2,Cities in Motion 2,steam,steam_icon_225420
 ClipGrab,clipgrab,/usr/share/pixmaps/clipgrab.png,clipgrab
 Codelite,codelite,/usr/share/codelite/images/cubes.png,codelite
 Conky Manager,conky-manager,/usr/share/pixmaps/conky-manager.png,conky-manager
+Copy,CopyAgent,/usr/share/icons/hicolor/scalable/apps/copyagent.svg,copyagent
 Crashplan,crashplan,/usr/local/crashplan/skin/icon_app_128x128.png,crashplan
 Crashplan,crashplan,/opt/crashplan/skin/icon_app_64x64.png,crashplan
 Cura,cura,/usr/share/cura/resources/images/c.png,cura


### PR DESCRIPTION
The standard path is /usr/share/freecad/freecad.xpm. Actually, one can update the tool to update a list of paths if they exist.