### PR TITLE
Added Cisco Packet Tracer

### DIFF
--- a/tofix.csv
+++ b/tofix.csv
@@ -33,6 +33,7 @@ Boot Repair,boot-repair,/usr/share/boot-sav/x-boot-repair.png,x-boot-repair
 Bygfoot Football Manager,bygfoot,bygfoot.xpm,bygfoot
 Calendar Indicator,calendar-indicator,/opt/extras.ubuntu.com/calendar-indicator/share/pixmaps/calendar-indicator.svg,office-calendar
 Cities in Motion 2,Cities in Motion 2,steam,steam_icon_225420
+Cisco Packet Tracer,Cisco-PacketTracer,/opt/pt/art/app.png,packettracer
 ClipGrab,clipgrab,/usr/share/pixmaps/clipgrab.png,clipgrab
 Codelite,codelite,/usr/share/codelite/images/cubes.png,codelite
 Conky Manager,conky-manager,/usr/share/pixmaps/conky-manager.png,conky-manager


### PR DESCRIPTION
Added a line for Cisco Packet Tracer, a packet simulator used in Cisco formations and in schools studying Networking & IT.

The path I added is for the Arch Linux package. As the app is stored in /opt on Arch, other distros might need another location added, too.