### PR TITLE
Add Teamviewer for arch

### DIFF
--- a/tofix.csv
+++ b/tofix.csv
@@ -329,11 +329,12 @@ SVG Cleaner,svgcleaner,/usr/share/icons/hicolor/scalable/apps/svgcleaner.svg,svg
 Syncthing-GTK,syncthing-gtk,/usr/share/syncthing-gtk/icons/st-logo-128.png,syncthing-gtk
 Synergy,synergy,/usr/share/icons/synergy.ico,synergy
 Teamspeak 3,TeamSpeak3,/opt/TeamSpeak3-Client-linux_amd64/styles/default/logo-128x128.png,teamspeak3
-Team Viewer,Teamviewer-teamviewer9,/opt/teamviewer9/tv_bin/desktop/teamviewer.png,teamviewer
-Team Viewer,teamviewer-teamviewer9,/opt/teamviewer9/tv_bin/desktop/teamviewer.png,teamviewer
-Team Viewer,teamviewer-teamviewer10,/opt/teamviewer/tv_bin/desktop/teamviewer.png,teamviewer
-Team Viewer,teamviewer-teamviewer10,/opt/teamviewer10/tv_bin/desktop/teamviewer.png,teamviewer
-Team Viewer,teamviewer-teamviewer11,/opt/teamviewer/tv_bin/desktop/teamviewer.png,teamviewer
+TeamViewer,Teamviewer-teamviewer9,/opt/teamviewer9/tv_bin/desktop/teamviewer.png,teamviewer
+TeamViewer,teamviewer-teamviewer9,/opt/teamviewer9/tv_bin/desktop/teamviewer.png,teamviewer
+TeamViewer,teamviewer-teamviewer10,/opt/teamviewer/tv_bin/desktop/teamviewer.png,teamviewer
+TeamViewer,teamviewer-teamviewer10,/opt/teamviewer10/tv_bin/desktop/teamviewer.png,teamviewer
+TeamViewer,teamviewer-teamviewer11,/opt/teamviewer/tv_bin/desktop/teamviewer.png,teamviewer
+TeamViewer,teamviewer,/opt/teamviewer/tv_bin/desktop/teamviewer.png,teamviewer
 Telegram,telegram,/usr/share/pixmaps/telegram.png,telegram
 Telegram,telegram,/opt/telegram/telegram.svg,telegram
 Terra Terminal Emulator,terra,/usr/share/terra/image/terra.svg,terra


### PR DESCRIPTION
Teamviewer aur package is using `teamviewer` as a desktop file name. I've also changed the application name as it's TeamViewer and not Team Viewer 