### PR TITLE
Another Octave fix

### DIFF
--- a/tofix.csv
+++ b/tofix.csv
@@ -114,6 +114,7 @@ GNUbik,gnubik,gnubik.png,gnubik
 GNU Octave,www.octave.org-octave,/usr/share/octave/3.6.4/imagelib/octave-logo.svg,octave
 GNU Octave,www.octave.org-octave,/usr/share/octave/3.8.1/imagelib/octave-logo.svg,octave
 GNU Octave,www.octave.org-octave,/usr/share/octave/4.0.0/imagelib/octave-logo.svg,octave
+GNU Octave,www.octave.org-octave,/usr/share/octave/4.0.1/imagelib/octave-logo.svg,octave
 Google Drive,grive-setup,/opt/thefanclub/grive-tools/GoogleDrive.png,google-drive
 Google Drive Indicator,grive-indicator,/opt/thefanclub/grive-tools/GoogleDrive.png,google-drive
 GoldenDict,goldendict,/usr/share/pixmaps/goldendict.png,goldendict


### PR DESCRIPTION
Good news: Here's the [upstream](http://hg.savannah.gnu.org/hgweb/octave/rev/87fc55416513) fix.