### PR TITLE
Fixes for Cecilia and Mancy

### DIFF
--- a/tofix.csv
+++ b/tofix.csv
@@ -34,6 +34,7 @@ BlueJ,bluej,/usr/share/java/bluej/images/bluej-icon-48.png,bluej
 Boot Repair,boot-repair,/usr/share/boot-sav/x-boot-repair.png,x-boot-repair
 Bygfoot Football Manager,bygfoot,bygfoot.xpm,bygfoot
 Calendar Indicator,calendar-indicator,/opt/extras.ubuntu.com/calendar-indicator/share/pixmaps/calendar-indicator.svg,office-calendar
+Cecilia,cecilia,/usr/share/pixmaps/cecilia.png,cecilia
 Cities in Motion 2,Cities in Motion 2,steam,steam_icon_225420
 Cisco Packet Tracer,Cisco-PacketTracer,/opt/pt/art/app.png,packettracer
 ClipGrab,clipgrab,/usr/share/pixmaps/clipgrab.png,clipgrab

--- a/tofix.csv
+++ b/tofix.csv
@@ -114,6 +114,7 @@ GNUbik,gnubik,gnubik.png,gnubik
 GNU Octave,www.octave.org-octave,/usr/share/octave/3.6.4/imagelib/octave-logo.svg,octave
 GNU Octave,www.octave.org-octave,/usr/share/octave/3.8.1/imagelib/octave-logo.svg,octave
 GNU Octave,www.octave.org-octave,/usr/share/octave/4.0.0/imagelib/octave-logo.svg,octave
+GNU Octave,www.octave.org-octave,/usr/share/octave/4.0.1/imagelib/octave-logo.svg,octave
 Google Drive,grive-setup,/opt/thefanclub/grive-tools/GoogleDrive.png,google-drive
 Google Drive Indicator,grive-indicator,/opt/thefanclub/grive-tools/GoogleDrive.png,google-drive
 GoldenDict,goldendict,/usr/share/pixmaps/goldendict.png,goldendict


### PR DESCRIPTION
Looks like a packaging issue since there is no ``.desktop`` launcher in the [upstream repo](https://github.com/belangeo/cecilia5).

Same for Mancy