### PR TITLE
Fix GNOME ALSA Mixer

### DIFF
--- a/tofix.csv
+++ b/tofix.csv
@@ -115,6 +115,7 @@ git-cola,git-cola,/usr/share/git-cola/icons/git.svg,git-cola
 Gitkraken,gitkraken,app,gitkraken
 Gitter,gitter,/opt/Gitter/linux64/logo.png,Gitter
 Gmsh,gmsh,/usr/share/pixmaps/gmsh_32x32.xpm,gmsh
+GNOME ALSA Mixer,gnome-alsamixer,/usr/share/pixmaps/gnome-alsamixer/gnome-alsamixer-icon.png,gnome-alsamixer-icon
 GNOME Schedule,gnome-schedule,/usr/share/pixmaps/gnome-schedule/gnome-schedule.svg,gnome-schedule
 GNOME Split,gnome-split,/usr/share/pixmaps/gnome-split.png,gnome-split
 GNOME Wave Cleaner,gwc,gwc.xpm,gwc


### PR DESCRIPTION
The .desktop file before:

```
[Desktop Entry]
Name=GNOME ALSA Mixer
Comment=ALSA sound mixer for GNOME
Comment[es]=Mezclador de sonido ALSA para GNOME
Comment[fr]=Mélangeur de son ALSA pour GNOME
Keywords=audio;sound;mixer;music;
Exec=gnome-alsamixer
Icon=/usr/share/pixmaps/gnome-alsamixer/gnome-alsamixer-icon.png
Terminal=false
Type=Application
Categories=AudioVideo;
X-Desktop-File-Install-Version=0.3
StartupNotify=true
```