### PR TITLE
add gtk-record-my-desktop

### DIFF
--- a/tofix.csv
+++ b/tofix.csv
@@ -151,6 +151,7 @@ Grsync,grsync,grsync.png,grsync
 Gsopcast,gsopcast,gsopcast.png,gsopcast
 GTick,gtick,/usr/share/icons/hicolor/64x64/apps/gtick.xpm,gtick
 GTimeLog,gtimelog,/usr/share/pyshared/gtimelog/gtimelog.png,gtimelog
+gtk-recordMyDesktop,gtk-recordmydesktop.desktop,gtk-recordmydesktop.png,gtk-recordmydesktop
 Guake,guake,/usr/share/pixmaps/guake/guake.png,guake
 GUVC View,guvcview,/usr/share/pixmaps/guvcview/guvcview.png,guvcview
 gv,gv,/usr/share/pixmaps/gv_icon.xpm,gv


### PR DESCRIPTION
This remove the extension from the icon name of gtk-recordmydesktop in archlinux