### PR TITLE
Fixed Etcher icon name

### DIFF
--- a/tofix.csv
+++ b/tofix.csv
@@ -83,7 +83,7 @@ Encrytr,encryptr,/usr/share/pixmaps/Encryptr.png,Encryptr
 Engauge Digitizer,engauge-digitizer,/usr/share/pixmpas/engauge-digitizer.xpm,engauge-digitizer
 Enpass,enpass,enpass.png,enpass
 Enpass,Enpass,/opt/Enpass/enpass.png,enpass
-Etcher,Etcher,/usr/share/etcher/etcher.png,etcher
+Etcher,Etcher,/usr/share/etcher/etcher.png,etcher-electron
 FadeIn,fadein,/usr/share/fadein/icon_app/fadein_icon_128x128.png,fadein
 FCEUX,fceux,/usr/share/pixmaps/fceux.png,fceux
 Fistful of Frags,Fistful of Frags,steam,steam_icon_265630

--- a/tofix.csv
+++ b/tofix.csv
@@ -83,6 +83,7 @@ Encrytr,encryptr,/usr/share/pixmaps/Encryptr.png,Encryptr
 Engauge Digitizer,engauge-digitizer,/usr/share/pixmpas/engauge-digitizer.xpm,engauge-digitizer
 Enpass,enpass,enpass.png,enpass
 Enpass,Enpass,/opt/Enpass/enpass.png,enpass
+Etcher,Etcher,/usr/share/etcher/etcher.png,etcher
 Etcher,Etcher,/usr/share/etcher/etcher.png,etcher-electron
 FadeIn,fadein,/usr/share/fadein/icon_app/fadein_icon_128x128.png,fadein
 FCEUX,fceux,/usr/share/pixmaps/fceux.png,fceux


### PR DESCRIPTION
Addendum: I don't know why, but these days Etcher by default stores the icon in weird location. It's smth like "/home/<USER>/.cache/thumbnails/normal/62aff500cfa829ae140de5e723814ce2.png" where PNG name is some kind of random. 
So, AFAIK, path "/usr/share/etcher/etcher.png" is wrong.