### PR TITLE
Added Autodesk Maya 2017

### DIFF
--- a/tofix.csv
+++ b/tofix.csv
@@ -225,6 +225,7 @@ Master PDF Editor,MasterPdfEditor,/opt/master-pdf-editor/master-pdf-editor.png,m
 Master PDF Editor 3,masterpdfeditor3,masterpdfeditor3.png,master-pdf-editor
 Master PDF Editor 3,masterpdfeditor3,/opt/master-pdf-editor-3/masterpdfeditor3.png,master-pdf-editor
 Matlab,matlab,/usr/share/icons/hicolor/48x48/apps/matlab.png,matlab
+Maya 2017,maya,/usr/autodesk/maya2017/icons/mayaico.png,maya
 MediaElch,MediaElch,/usr/share/pixmaps/MediaElch.png,mediaelch
 MidiEditor,MidiEditor,midieditor.png,midieditor
 Mint Audio Tag,audio-tag-tool,/usr/lib/linuxmint/mintInstall/icon.svg,audio-tag-tool


### PR DESCRIPTION
Maya 2017, on Arch at least, uses an hardocded icon to `/usr/autodesk/maya2017/icons/mayaico.png`.

This replaces it with `maya`.