### PR TITLE
Next

### DIFF
--- a/fix.sh
+++ b/fix.sh
@@ -30,6 +30,27 @@ readonly PROGNAME="hardcode-fixer"
 declare -i VERSION=201710170  # [year][month][date][extra]
 # date=999999990  # deprecate the previous version
 
+declare DB_URL="https://raw.githubusercontent.com/Foggalong/hardcode-fixer/master/tofix.csv"
+declare LOCAL_APPS_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+declare LOCAL_ICONS_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/icons"
+
+declare -a GLOBAL_APPS_DIRS=(
+	"/usr/share/applications"
+	"/usr/share/applications/kde4"
+	"/usr/local/share/applications"
+	"/usr/local/share/applications/kde4"
+)
+
+declare -a LOCAL_APPS_DIRS=(
+	"${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+	"${XDG_DATA_HOME:-$HOME/.local/share}/applications/kde4"
+	"$(xdg-user-dir DESKTOP)"
+)
+
+# default values of options
+declare -i FORCE_DOWNLOAD=0
+declare -i VERBOSE=0
+
 message() {
 	printf "%s: %b\n" "$PROGNAME" "$*" >&2
 }
@@ -501,27 +522,6 @@ main() {
 	if [ "$(id -u)" -eq 0 ]; then
 		fail "This script must be run as normal user."
 	fi
-
-	declare DB_URL="https://raw.githubusercontent.com/Foggalong/hardcode-fixer/master/tofix.csv"
-	declare LOCAL_APPS_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
-	declare LOCAL_ICONS_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/icons"
-
-	declare -a GLOBAL_APPS_DIRS=(
-		"/usr/share/applications"
-		"/usr/share/applications/kde4"
-		"/usr/local/share/applications"
-		"/usr/local/share/applications/kde4"
-	)
-
-	declare -a LOCAL_APPS_DIRS=(
-		"${XDG_DATA_HOME:-$HOME/.local/share}/applications"
-		"${XDG_DATA_HOME:-$HOME/.local/share}/applications/kde4"
-		"$(xdg-user-dir DESKTOP)"
-	)
-
-	# default values of options
-	declare -i FORCE_DOWNLOAD=0
-	declare -i VERBOSE=0
 
 	if [ "${#ARGS[@]}" -gt 0 ]; then
 		cmdline

--- a/fix.sh
+++ b/fix.sh
@@ -423,7 +423,7 @@ cmdline() {
 			*)
 				message "illegal option -- '$arg'"
 				show_usage
-				exit 2
+				exit 128
 				;;
 		esac
 	done

--- a/fix.sh
+++ b/fix.sh
@@ -70,11 +70,13 @@ fail() {
 }
 
 _is_hardcoded() {
+	# returns true if Icon contains a path
 	local desktop_file="$1"
 	LANG=C grep -q '^Icon=.*/.*' -- "$desktop_file"
 }
 
 _is_hardcoded_steam_app() {
+	# returns true if is a Steam launcher and Icon equals 'steam'
 	local desktop_file="$1"
 	local icon_name
 
@@ -149,7 +151,7 @@ set_marker_value() {
 }
 
 icon_lookup() {
-	# returns path to an icon (icon lookup for poor man)
+	# looks for icon in the list of dirs and returns absolute path to the icon
 	local icon_name="$1"
 	local -a icons_dirs=(
 		"/usr/share/icons/hicolor/48x48/apps"
@@ -172,6 +174,7 @@ icon_lookup() {
 }
 
 get_icon_path() {
+	# returns absolute path to the icon
 	local desktop_file="$1"
 	local icon_value icon_path
 

--- a/fix.sh
+++ b/fix.sh
@@ -230,7 +230,7 @@ get_upstream_version() {
 	download_file "$upstream_file" \
 		| LANG=C grep -o 'date=[0-9]\+' \
 		| head -1 \
-		| tr -dc '[0-9]'
+		| tr -cd '[:digit:]'
 }
 
 get_from_db() {

--- a/fix.sh
+++ b/fix.sh
@@ -48,8 +48,8 @@ declare -a LOCAL_APPS_DIRS=(
 )
 
 # default values of options
-declare -i FORCE_DOWNLOAD=0
-declare -i VERBOSE=0
+declare -i FORCE_DOWNLOAD="${FORCE_DOWNLOAD:-0}"
+declare -i VERBOSE="${VERBOSE:-0}"
 
 message() {
 	printf "%s: %b\n" "$PROGNAME" "$*" >&2
@@ -345,7 +345,6 @@ apply() {
 			[ -f "$desktop_file" ] || continue
 			if _is_hardcoded "$desktop_file"; then
 				fix_hardcoded_app "$desktop_file" "global" || continue
-				continue
 			fi
 		done
 	done
@@ -357,8 +356,6 @@ apply() {
 				fix_hardcoded_app "$desktop_file" "local" || continue
 			elif _is_hardcoded_steam_app "$desktop_file"; then
 				fix_hardcoded_app "$desktop_file" "steam" || continue
-			else
-				continue
 			fi
 		done
 	done
@@ -466,10 +463,8 @@ cmdline() {
 }
 
 show_menu() {
-	local -a menu_items=( "apply" "revert" "verbose" "help" "quit" )
-	local num_items="${#menu_items[@]}"
-	local PS3="[1-${num_items}]> "  # set custom prompt
-	local COLUMNS=1  # force listing to be vertical
+	local -a menu_items=( "apply" "revert" "help" "quit" )
+	local PS3="($PROGNAME)> "  # set custom prompt
 
 	cat >&2 <<- EOF
 	Welcome to $PROGNAME ($VERSION)!
@@ -488,22 +483,15 @@ show_menu() {
 				revert
 				break
 				;;
-			verbose|verb*)
-				VERBOSE=1
-				message "Verbose mode is enabled."
-				;;
 			help|[hH]*)
 				cat >&2 <<- EOF
-
 				 apply     —  Fixes hardcoded icons of installed applications
 				 revert    —  Reverts any changes made
-				 verbose   -  Be verbose
 				 help      —  Displays this help menu
 				 quit      -  Quit "$PROGNAME"
-
 				EOF
 				;;
-			quit|[qQ]*)
+			quit|[qQ]*|[eE]*)
 				exit 0
 				;;
 			*)

--- a/fix.sh
+++ b/fix.sh
@@ -27,7 +27,7 @@ readonly SCRIPT_DIR="$(dirname -- "$0")"
 readonly -a ARGS=("$@")
 
 readonly PROGNAME="hardcode-fixer"
-declare -i VERSION=201710140  # [year][month][date][extra]
+declare -i VERSION=201710170  # [year][month][date][extra]
 # date=999999990  # deprecate the previous version
 
 message() {
@@ -244,8 +244,12 @@ restore_desktop_file() {
 	base_name="$(basename "$desktop_file")"
 	file_path="${dir_name}/.${base_name}.orig"
 
-	[ -f "$file_path" ] || return 1
-	mv -f "$file_path" "$desktop_file"
+	if [ -f "$file_path" ]; then
+		mv -f "$file_path" "$desktop_file"
+	else
+		warning "Can't find the backup file. Skipping."
+		return 1
+	fi
 }
 
 fix_hardcoded_app() {
@@ -358,7 +362,7 @@ revert() {
 						rm -f -- "$desktop_file"
 						;;
 					local|steam)
-						restore_desktop_file "$desktop_file"
+						restore_desktop_file "$desktop_file" || continue
 						;;
 				esac
 

--- a/fix.sh
+++ b/fix.sh
@@ -356,6 +356,7 @@ revert() {
 			[ -f "$desktop_file" ] || continue
 
 			app_name="$(get_app_name "$desktop_file")"
+			icon_name="$(get_icon_name "$desktop_file")"
 			marker_value="$(get_marker_value "$desktop_file")"
 
 			if [ -n "$marker_value" ]; then
@@ -364,8 +365,15 @@ revert() {
 				if [ "$marker_value" = "local" ]; then
 					restore_desktop_file "$desktop_file"
 				else
-					rm -f "$desktop_file"
+					rm -f -- "$desktop_file"
 				fi
+
+				verbose "Removing '$icon_name' icon ..."
+				for ext in png svg xpm; do
+					[ -f "$LOCAL_ICONS_DIR/$icon_name.$ext" ] || continue
+					rm -- "$LOCAL_ICONS_DIR/$icon_name.$ext"
+					break
+				done
 			fi
 		done
 	done

--- a/fix.sh
+++ b/fix.sh
@@ -216,13 +216,18 @@ get_from_db() {
 translate_from_app_name() {
 	local desktop_file="$1"
 
-	# 1. to lowercase
-	# 2. delete invalid characters
-	# 3. replace spaces with minus
+	# 1. remove text between parentheses
+	# 2. replace spaces with hyphens
+	# 3. replace two or more hyphens by one
+	# 4. to lowercase
+	# 5. delete invalid characters
 	get_app_name "$desktop_file" \
+		| sed \
+			-e 's/[ ]([^)]\+)//g' \
+			-e 's/[ ]/-/g' \
+			-e 's/-\+/-/g' \
 		| tr '[:upper:]' '[:lower:]' \
-		| tr -cd '[:alnum:]-_. ' \
-		| sed -e 's/[ ]/-/g'
+		| tr -cd '[:alnum:]-_'
 }
 
 backup_desktop_file() {


### PR DESCRIPTION
Here is the first stage of improvements to the next version hardcode-fixer.

There is a simple diagram that can help to understand how the script works [dia.pdf](https://github.com/Foggalong/hardcode-fixer/files/1468084/dia.pdf).

### Requires

- bash >= 4 (included in all actual distros)
- GNU sed
- awk (prefer gawk but should work with any version)
- wget | curl (curl is not installed by default in Ubuntu 16.10 and newer, wget is not installed by default in Manjaro)

### Features

- Supports [XDG Base Directory Specification](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) #310
- Converts invalid icon formats to png #306
- No requires root permission #178
- Auto-translate application name to icon name if matches not found in tofix.csv #220 #285
- Extendable code (as much as possible in bash)
- Has two user interface:
	- Simple interactive menu (when args or commands not passed)
		Extremely useful when executing via 'Run in Terminal' and through a pipe: `wget -qO- URL | bash`.
	- Advanced command line.
        ```sh
        # the commands in this example do the same
        hardcode-fixer -Av
        hardcode-fixer --apply --verbose
        hardcode-fixer apply -v
        ```
- Fixes launchers on user desktop and hides backup files to avoid littering
- Compatible with current version of tofix.csv

### Limitations

- doesn't work in BSD-systems. It's easy to fix, but the code will be ugly.
- can't undo changes that made by the previous version (from master branch)

### ToDo

- [ ] cleanup tofix.csv:
  - [ ] remove duplicates with the same app name
  - [ ] fix the wrong app names
  - [ ] delete Steam app entries
- [ ] fix launchers with non-standard extensions (`Icon=zotero.ico`, etc..)
- [ ] add bash and zsh completions
- [ ] add colors for output messages (?)

**NOTE:** This PR can be merged. The improvements in the list will be added in another.